### PR TITLE
fix: Django 4.x compatibility

### DIFF
--- a/light_gallery/cms_plugins.py
+++ b/light_gallery/cms_plugins.py
@@ -1,6 +1,10 @@
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
-from django.utils.translation import ugettext_lazy as _
+import django
+if django.VERSION[0] < 4:
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
 
 from .models import LightGallery
 

--- a/light_gallery/models.py
+++ b/light_gallery/models.py
@@ -1,5 +1,9 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+import django
+if django.VERSION[0] < 4:
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
 from cms.models.pluginmodel import CMSPlugin
 from filer.fields.folder import FilerFolderField
 from filer.models.imagemodels import Image

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='djangocms-light-gallery',
-      version='1.2.0',
+      version='1.2.1',
       description='Light Gallery plugin for django CMS',
       url='https://github.com/andyklimczak/djangocms-light-gallery',
       author='Andy Klimczak',


### PR DESCRIPTION
Make this plugin compatible with Django 4.x and bump version to 1.2.1.

Function `ugettext_lazy` is deprecated earlier and removed since Django 4.0.
For more details see [Features removed in 4.0](https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0) of Django release notes..